### PR TITLE
Fixed Blazor part

### DIFF
--- a/Pragmatic.Client.BlazorServer/Models/ValueModel.cs
+++ b/Pragmatic.Client.BlazorServer/Models/ValueModel.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pragmatic.Client.BlazorServer.Models
+{
+    public class ValueModel : IDisposable
+    {
+        private bool disposedValue;
+
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects)
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                disposedValue = true;
+            }
+        }
+
+        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+        // ~ValueModel()
+        // {
+        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        //     Dispose(disposing: false);
+        // }
+
+        void IDisposable.Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Pragmatic.Client.BlazorServer/Pages/CallWebApi.razor
+++ b/Pragmatic.Client.BlazorServer/Pages/CallWebApi.razor
@@ -1,5 +1,5 @@
 @page "/callwebapi"
-
+@attribute [Authorize]
 @inject IDownstreamApi downstreamAPI
 @inject MicrosoftIdentityConsentAndConditionalAccessHandler ConsentHandler
 @inject APIOptions apiOptions
@@ -15,18 +15,20 @@
 else
 {
     <h2>API Result</h2>
-    @apiResult
+    @foreach(var item in apiResult)
+    {
+        <p>@(item.Name) [#@(item.Id)]</p>
+    }
+
 }
 
 @code {
-    private HttpResponseMessage response;
-    private string apiResult;
-
+    private IEnumerable<ValueModel> apiResult = null;
     protected override async Task OnInitializedAsync()
     {
         try
         {
-            response = await downstreamAPI.CallApiForUserAsync(
+            apiResult = await downstreamAPI.GetForUserAsync<IEnumerable<ValueModel>>(
                     "DownstreamApi",
                     options =>
                     {
@@ -34,15 +36,7 @@ else
                         options.RelativePath = "values"; // NB! "api/" is included in the default BaseAddress
                     }
             );
-            
-            if (response.StatusCode == System.Net.HttpStatusCode.OK)
-            {
-                apiResult = await response.Content.ReadAsStringAsync();
-            }
-            else
-            {
-                apiResult = "Failed to call the web API";
-            }
+
         }
         catch (Exception ex)
         {

--- a/Pragmatic.Client.BlazorServer/appsettings.json
+++ b/Pragmatic.Client.BlazorServer/appsettings.json
@@ -17,7 +17,7 @@
   "AllowedHosts": "*",
   "DownstreamApi": {
     "BaseUrl": "api://32ab702c-a65c-4506-a9d1-26911115765b/",
-    "Scopes": "api://32ab702c-a65c-4506-a9d1-26911115765b/AllAccess",
+    "Scopes": [ "api://32ab702c-a65c-4506-a9d1-26911115765b/AllAccess" ],
     "BaseAddress": "https://localhost:7086/api/"
   }
 }


### PR DESCRIPTION
The part that was making problem was configuration of scopes. Migration from v1 (DownstreamWebApi) to v2 (DownstreamApi) changed this from single string with scopes joined by space to array of strings. There was a mention in migration, that not changin it will cause receiving 401.

I've added also [Authorize] attribute to razor page. Probably it'd work without it, but when user wouldn't be logged in api call would return 401 (unauthorized)